### PR TITLE
Update kafka version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,13 +9,13 @@ plugins {
     id 'maven-publish'
 }
 
-version = '0.1'
+version = '0.1.1'
 
 targetCompatibility = '1.8'
 sourceCompatibility = '1.8'
 
 ext.slf4jVersion = '1.7.21'
-ext.kafkaVersion = '0.10.1.1'
+ext.kafkaVersion = '0.10.2.1'
 ext.mongodbVersion = '3.3.0'
 
 ext.junitVersion = '4.12'


### PR DESCRIPTION
Update to new kafka version to avoid a version mismatch between the connector code and the docker image. 
A new release is required to include it in RADAR-MongoDB-Sink-Connector