### PR TITLE
Use MongoDB URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,28 +96,20 @@ Modify [sink.properties](https://github.com/RADAR-base/MongoDb-Sink-Connector/bl
 <th>Importance</th>
 </tr>
 <tr>
-<td>topics</td><td>List of topics to be streamed.</td><td>list</td><td></td><td></td><td>high</td></tr>
+<td>topics</td></td><td>List of topics to be streamed.</td></td><td>list</td></td><td></td></td><td></td></td><td>high</td></td></tr>
 <tr>
-<td>record.converter.class</td><td>RecordConverterFactory that returns classes to convert Kafka SinkRecords to BSON documents.</td><td>class</td><td>org.radarcns.connect.mongodb.serialization.RecordConverterFactory</td><td>org.radarcns.connect.util.ValidClass@48cf768c</td><td>medium</td></tr>
+<td>record.converter.class</td></td><td>RecordConverterFactory that returns classes to convert Kafka SinkRecords to BSON documents.</td></td><td>class</td></td><td>org.radarcns.connect.mongodb.serialization.RecordConverterFactory</td></td><td>Class extending org.radarcns.connect.mongodb.serialization.RecordConverterFactory</td></td><td>medium</td></td></tr>
 <tr>
-<td>batch.flush.ms</td><td>Flush a batch after this amount of milliseconds.</td><td>int</td><td>15000</td><td>[0,...]</td><td>low</td></tr>
+<td>batch.flush.ms</td></td><td>Flush a batch after this amount of milliseconds.</td></td><td>int</td></td><td>15000</td></td><td>[0,...]</td></td><td>low</td></td></tr>
 <tr>
-<td>batch.size</td><td>Batch size to initiate a MongoDB write operation. If the buffer does not reach this capacity within batch.flush.ms, it will be written anyway.</td><td>int</td><td>2500</td><td>[1,...]</td><td>low</td></tr>
+<td>batch.size</td></td><td>Batch size to initiate a MongoDB write operation. If the buffer does not reach this capacity within batch.flush.ms, it will be written anyway.</td></td><td>int</td></td><td>2500</td></td><td>[1,...]</td></td><td>low</td></td></tr>
 <tr>
-<td>buffer.capacity</td><td>Maximum number of items in a MongoDB writer buffer. Once the buffer becomes full, the task fails.</td><td>int</td><td>20000</td><td>[1,...]</td><td>low</td></tr>
+<td>buffer.capacity</td></td><td>Maximum number of items in a MongoDB writer buffer. Once the buffer becomes full, the task fails.</td></td><td>int</td></td><td>20000</td></td><td>[1,...]</td></td><td>low</td></td></tr>
 <tr>
-<td>mongo.host</td><td>MongoDB host name to write data to</td><td>string</td><td></td><td>org.radarcns.connect.util.NotEmptyString@59f95c5d</td><td>high</td></tr>
+<td>mongo.uri</td></td><td>URI encoding MongoDB host, port, user (if any) and database.</td></td><td>string</td></td><td></td></td><td>(mongodb|mongodb+srv)://[<user>:<password>@]<host>[:<port>]/<database></td></td><td>high</td></td></tr>
 <tr>
-<td>mongo.port</td><td>MongoDB port</td><td>int</td><td>27017</td><td>[1,...]</td><td>low</td></tr>
-<tr>
-<td>mongo.database</td><td>MongoDB database name</td><td>string</td><td></td><td>org.radarcns.connect.util.NotEmptyString@5ccd43c2</td><td>high</td></tr>
-<tr>
-<td>mongo.username</td><td>Username to connect to MongoDB database. If not set, no credentials are used.</td><td>string</td><td>null</td><td></td><td>medium</td></tr>
-<tr>
-<td>mongo.password</td><td>Password to connect to MongoDB database. If not set, no credentials are used.</td><td>string</td><td>null</td><td></td><td>medium</td></tr>
-<tr>
-<td>mongo.collection.format</td><td>A format string for the destination collection name, which may contain `${topic}` as a placeholder for the originating topic name.
-For example, `kafka_${topic}` for the topic `orders` will map to the collection name `kafka_orders`.</td><td>string</td><td>{$topic}</td><td>org.radarcns.connect.util.NotEmptyString@4aa8f0b4</td><td>medium</td></tr>
+<td>mongo.collection.format</td></td><td>A format string for the destination collection name, which may contain `${topic}` as a placeholder for the originating topic name.
+For example, `kafka_${topic}` for the topic `orders` will map to the collection name `kafka_orders`.</td></td><td>string</td></td><td>{$topic}</td></td><td>Non-empty string</td></td><td>medium</td></td></tr>
 </tbody></table>
 
 - A sample configuration may look as below.
@@ -133,13 +125,7 @@ For example, `kafka_${topic}` for the topic `orders` will map to the collection 
     # Topics that will be consumed
     topics=avrotest
     # MongoDB server
-    mongo.host=localhost
-    mongo.port=27017
-    
-    # MongoDB configuration
-    mongo.username=mongodb-username
-    mongo.password=***
-    mongo.database=mongodb-database
+    mongo.uri=mongodb://me:pass123@localhost/kafka-db
     
     # Collection name for putting data into the MongoDB database. The {$topic} token will be replaced
     # by the Kafka topic name.

--- a/sink.properties
+++ b/sink.properties
@@ -8,13 +8,7 @@ tasks.max=1
 # Topics that will be consumed
 topics=avrotest
 # MongoDB server
-mongo.host=localhost
-mongo.port=27017
-
-# MongoDB configuration
-mongo.username=
-mongo.password=
-mongo.database=
+mongo.uri=mongodb://myuser:mypassword@localhost/mydatabase
 
 # Collection name for putting data into the MongoDB database. The {$topic} token will be replaced
 # by the Kafka topic name.

--- a/src/main/java/org/radarcns/connect/mongodb/MongoDbSinkConnector.java
+++ b/src/main/java/org/radarcns/connect/mongodb/MongoDbSinkConnector.java
@@ -27,6 +27,7 @@ import org.radarcns.connect.mongodb.serialization.RecordConverterFactory;
 import org.radarcns.connect.util.NotEmptyString;
 import org.radarcns.connect.util.Utility;
 import org.radarcns.connect.util.ValidClass;
+import org.radarcns.connect.util.ValidMongoUri;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,12 +49,7 @@ public class MongoDbSinkConnector extends SinkConnector {
     private static final Logger logger = LoggerFactory.getLogger(MongoDbSinkConnector.class);
 
     public static final String MONGO_GROUP = "MongoDB";
-    public static final String MONGO_HOST = "mongo.host";
-    public static final String MONGO_PORT = "mongo.port";
-    public static final int MONGO_PORT_DEFAULT = 27017;
-    public static final String MONGO_USERNAME = "mongo.username";
-    public static final String MONGO_PASSWORD = "mongo.password";
-    public static final String MONGO_DATABASE = "mongo.database";
+    public static final String MONGO_URI = "mongo.uri";
     public static final String BUFFER_CAPACITY = "buffer.capacity";
     public static final int BUFFER_CAPACITY_DEFAULT = 20_000;
     public static final String BATCH_SIZE = "batch.size";
@@ -64,22 +60,9 @@ public class MongoDbSinkConnector extends SinkConnector {
     public static final String RECORD_CONVERTER = "record.converter.class";
 
     static final ConfigDef CONFIG_DEF = new ConfigDef()
-            .define(MONGO_HOST, Type.STRING, NO_DEFAULT_VALUE, new NotEmptyString(), HIGH,
-                "MongoDB host name to write data to", MONGO_GROUP, 0, ConfigDef.Width.MEDIUM,
-                "MongoDB hostname")
-            .define(MONGO_PORT, Type.INT, MONGO_PORT_DEFAULT, ConfigDef.Range.atLeast(1),
-                LOW, "MongoDB port", MONGO_GROUP, 1, ConfigDef.Width.SHORT, "MongoDB port")
-            .define(MONGO_DATABASE, Type.STRING, NO_DEFAULT_VALUE, new NotEmptyString(),
-                HIGH, "MongoDB database name", MONGO_GROUP, 2, ConfigDef.Width.SHORT,
-                "MongoDB database")
-            .define(MONGO_USERNAME, Type.STRING, null, MEDIUM,
-                "Username to connect to MongoDB database. If not set, no credentials are used.",
-                    MONGO_GROUP, 3, ConfigDef.Width.SHORT, "MongoDB username",
-                Collections.singletonList(MONGO_PASSWORD))
-            .define(MONGO_PASSWORD, Type.STRING, null, MEDIUM,
-                "Password to connect to MongoDB database. If not set, no credentials are used.",
-                    MONGO_GROUP, 4, ConfigDef.Width.SHORT, "MongoDB password",
-                Collections.singletonList(MONGO_USERNAME))
+            .define(MONGO_URI, Type.STRING, NO_DEFAULT_VALUE, new ValidMongoUri(), HIGH,
+                "URI encoding MongoDB host, port, user (if any) and database.",
+                    MONGO_GROUP, 0, ConfigDef.Width.MEDIUM, "MongoDB URI")
             .define(COLLECTION_FORMAT, Type.STRING, "{$topic}", new NotEmptyString(), MEDIUM,
                 "A format string for the destination collection name, which may contain "
                 + "`${topic}` as a placeholder for the originating topic name.\n"

--- a/src/main/java/org/radarcns/connect/util/NotEmptyString.java
+++ b/src/main/java/org/radarcns/connect/util/NotEmptyString.java
@@ -32,4 +32,9 @@ public class NotEmptyString implements ConfigDef.Validator {
             throw new ConfigException(name, value, "String may not be empty");
         }
     }
+
+    @Override
+    public String toString() {
+        return "Non-empty string";
+    }
 }

--- a/src/main/java/org/radarcns/connect/util/ValidClass.java
+++ b/src/main/java/org/radarcns/connect/util/ValidClass.java
@@ -55,4 +55,8 @@ public final class ValidClass implements ConfigDef.Validator {
             throw new ConfigException(name, obj, "Class " + obj + " must be accessible: " + ex);
         }
     }
+
+    public String toString() {
+        return "Class extending " + superClass.getName();
+    }
 }

--- a/src/main/java/org/radarcns/connect/util/ValidMongoUri.java
+++ b/src/main/java/org/radarcns/connect/util/ValidMongoUri.java
@@ -1,0 +1,35 @@
+package org.radarcns.connect.util;
+
+import com.mongodb.MongoClientException;
+import com.mongodb.MongoClientURI;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+
+public class ValidMongoUri implements ConfigDef.Validator {
+    @Override
+    public void ensureValid(String name, Object value) {
+        if (value == null || value.toString().trim().isEmpty()) {
+            throw new ConfigException("URL is empty");
+        }
+        String uri = value.toString().trim();
+        MongoClientURI mongoUri;
+        try {
+            mongoUri = new MongoClientURI(value.toString());
+        } catch (IllegalArgumentException | MongoClientException ex) {
+            throw new ConfigException("Cannot parse URI " + uri, ex);
+        }
+
+        if (mongoUri.getHosts().isEmpty() || mongoUri.getHosts().get(0).isEmpty()) {
+            throw new ConfigException("MongoDB URI does not specify host");
+        }
+
+        if (mongoUri.getDatabase() == null) {
+            throw new ConfigException("MongoDB URI does not specify database");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "(mongodb|mongodb+srv)://[<user>:<password>@]<host>[:<port>]/<database>";
+    }
+}

--- a/src/test/java/org/radarcns/connect/mongodb/MongoDbSinkConnectorTest.java
+++ b/src/test/java/org/radarcns/connect/mongodb/MongoDbSinkConnectorTest.java
@@ -27,48 +27,38 @@ import static org.apache.kafka.connect.sink.SinkConnector.TOPICS_CONFIG;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.radarcns.connect.mongodb.MongoDbSinkConnector.BUFFER_CAPACITY;
 import static org.radarcns.connect.mongodb.MongoDbSinkConnector.COLLECTION_FORMAT;
-import static org.radarcns.connect.mongodb.MongoDbSinkConnector.MONGO_DATABASE;
-import static org.radarcns.connect.mongodb.MongoDbSinkConnector.MONGO_HOST;
-import static org.radarcns.connect.mongodb.MongoDbSinkConnector.MONGO_PORT;
-import static org.radarcns.connect.mongodb.MongoDbSinkConnector.MONGO_PORT_DEFAULT;
-import static org.radarcns.connect.mongodb.MongoDbSinkConnector.MONGO_USERNAME;
+import static org.radarcns.connect.mongodb.MongoDbSinkConnector.MONGO_URI;
 
 public class MongoDbSinkConnectorTest {
     @Test
-    public void taskClass() throws Exception {
+    public void taskClass() {
         assertEquals(MongoDbSinkTask.class, new MongoDbSinkConnector().taskClass());
     }
 
     @Test
-    public void taskConfigs() throws Exception {
+    public void taskConfigs() {
         assertThat(new MongoDbSinkConnector().taskConfigs(0), hasSize(0));
         assertThat(new MongoDbSinkConnector().taskConfigs(10), hasSize(10));
     }
 
     @Test
-    public void configParse() throws Exception {
+    public void configParse() {
         Map<String, String> exampleConfig = new HashMap<>();
-        exampleConfig.put(MONGO_HOST, "localhost");
-        exampleConfig.put(MONGO_DATABASE, "mydb");
+        exampleConfig.put(MONGO_URI, "mongodb://localhost/mydb");
         exampleConfig.put(TOPICS_CONFIG, "mytopic,myothertopic");
         exampleConfig.put(BUFFER_CAPACITY, "2");
         Map<String, Object> result = new MongoDbSinkConnector().config().parse(exampleConfig);
         assertEquals(2, result.get(BUFFER_CAPACITY));
-        assertEquals(MONGO_PORT_DEFAULT, result.get(MONGO_PORT));
-        assertEquals("localhost", result.get(MONGO_HOST));
         assertThat((Collection<?>)result.get(TOPICS_CONFIG), contains("mytopic", "myothertopic"));
-        assertNull(result.get(MONGO_USERNAME));
     }
 
     @Test(expected = ConfigException.class)
     public void configParseInvalidValue() throws Exception {
         Map<String, String> exampleConfig = new HashMap<>();
-        exampleConfig.put(MONGO_HOST, "localhost");
-        exampleConfig.put(MONGO_DATABASE, "mydb");
+        exampleConfig.put(MONGO_URI, "mongodb://localhost/mydb");
         exampleConfig.put(TOPICS_CONFIG, "mytopic,myothertopic");
         // capacity is invalid
         exampleConfig.put(BUFFER_CAPACITY, "-1");
@@ -79,8 +69,7 @@ public class MongoDbSinkConnectorTest {
     @Test(expected = ConfigException.class)
     public void configParseEmptyValue() throws Exception {
         Map<String, String> exampleConfig = new HashMap<>();
-        exampleConfig.put(MONGO_HOST, "");
-        exampleConfig.put(MONGO_DATABASE, "mydb");
+        exampleConfig.put(MONGO_URI, "mongodb://localhost/mydb");
         exampleConfig.put(TOPICS_CONFIG, "mytopic,myothertopic");
         // empty string not allowed
         exampleConfig.put(COLLECTION_FORMAT, "");
@@ -91,8 +80,7 @@ public class MongoDbSinkConnectorTest {
     @Test
     public void start() {
         Map<String, String> exampleConfig = new HashMap<>();
-        exampleConfig.put(MONGO_HOST, "localhost");
-        exampleConfig.put(MONGO_DATABASE, "mydb");
+        exampleConfig.put(MONGO_URI, "mongodb://localhost/mydb");
         exampleConfig.put(TOPICS_CONFIG, "mytopic,myothertopic");
         exampleConfig.put(BUFFER_CAPACITY, "2");
         new MongoDbSinkConnector().start(exampleConfig);
@@ -101,8 +89,7 @@ public class MongoDbSinkConnectorTest {
     @Test(expected = ConfigException.class)
     public void startInvalid() {
         Map<String, String> exampleConfig = new HashMap<>();
-        exampleConfig.put(MONGO_HOST, "");
-        exampleConfig.put(MONGO_DATABASE, "mydb");
+        exampleConfig.put(MONGO_URI, "mongodb:///mydb");
         exampleConfig.put(TOPICS_CONFIG, "mytopic,myothertopic");
         // empty string not allowed
         exampleConfig.put(COLLECTION_FORMAT, "");

--- a/src/test/java/org/radarcns/connect/mongodb/MongoDbSinkTaskTest.java
+++ b/src/test/java/org/radarcns/connect/mongodb/MongoDbSinkTaskTest.java
@@ -36,8 +36,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.radarcns.connect.mongodb.MongoDbSinkConnector.BUFFER_CAPACITY;
-import static org.radarcns.connect.mongodb.MongoDbSinkConnector.MONGO_DATABASE;
-import static org.radarcns.connect.mongodb.MongoDbSinkConnector.MONGO_HOST;
+import static org.radarcns.connect.mongodb.MongoDbSinkConnector.MONGO_URI;
 import static org.radarcns.connect.mongodb.MongoDbSinkConnector.RECORD_CONVERTER;
 import static org.radarcns.connect.mongodb.MongoDbSinkConnector.TOPICS_CONFIG;
 
@@ -54,8 +53,7 @@ public class MongoDbSinkTaskTest {
                 .createMongoDbWriter(any(), any(), anyInt(), anyLong(), any(), any());
 
         Map<String, String> config = new HashMap<>();
-        config.put(MONGO_DATABASE, "db");
-        config.put(MONGO_HOST, "localhost");
+        config.put(MONGO_URI, "mongodb://localhost/db");
         config.put(TOPICS_CONFIG, "t");
         config.put(BUFFER_CAPACITY, String.valueOf(10));
         config.put(RECORD_CONVERTER, RecordConverterFactory.class.getName());

--- a/src/test/java/org/radarcns/connect/mongodb/MongoWrapperTest.java
+++ b/src/test/java/org/radarcns/connect/mongodb/MongoWrapperTest.java
@@ -24,50 +24,32 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.kafka.connect.sink.SinkConnector.TOPICS_CONFIG;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.radarcns.connect.mongodb.MongoDbSinkConnector.COLLECTION_FORMAT;
 import static org.radarcns.connect.mongodb.MongoDbSinkConnector.CONFIG_DEF;
-import static org.radarcns.connect.mongodb.MongoDbSinkConnector.MONGO_DATABASE;
-import static org.radarcns.connect.mongodb.MongoDbSinkConnector.MONGO_HOST;
-import static org.radarcns.connect.mongodb.MongoDbSinkConnector.MONGO_PASSWORD;
-import static org.radarcns.connect.mongodb.MongoDbSinkConnector.MONGO_PORT;
-import static org.radarcns.connect.mongodb.MongoDbSinkConnector.MONGO_PORT_DEFAULT;
-import static org.radarcns.connect.mongodb.MongoDbSinkConnector.MONGO_USERNAME;
+import static org.radarcns.connect.mongodb.MongoDbSinkConnector.MONGO_URI;
 
 public class MongoWrapperTest {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
     @Test
-    public void checkConnectionWithoutCredentials() throws Exception {
+    public void checkConnectionWithoutCredentials() {
         Map<String, Object> configMap = new HashMap<>();
-        configMap.put(MONGO_USERNAME, null);
-        configMap.put(MONGO_PASSWORD, null);
-        configMap.put(MONGO_PORT, MONGO_PORT_DEFAULT + 1000);
-        configMap.put(MONGO_HOST, "localhost");
-        configMap.put(MONGO_DATABASE, "mydb");
+        configMap.put(MONGO_URI, "mongodb://localhost:28017/mydb");
         configMap.put(COLLECTION_FORMAT, "{$topic}");
         configMap.put(TOPICS_CONFIG, "a");
 
-        Field credentialsField = MongoWrapper.class.getDeclaredField("credentials");
-        credentialsField.setAccessible(true);
-        MongoClientOptions timeout = MongoClientOptions.builder()
+        MongoClientOptions.Builder timeout = MongoClientOptions.builder()
                 .connectTimeout(1)
                 .socketTimeout(1)
-                .serverSelectionTimeout(1)
-                .build();
+                .serverSelectionTimeout(1);
         MongoWrapper wrapper = new MongoWrapper(new AbstractConfig(CONFIG_DEF, configMap), timeout);
 
-        assertThat(credentialsField.get(wrapper), is(nullValue()));
         assertFalse(wrapper.checkConnection());
 
         thrown.expect(MongoException.class);
@@ -79,57 +61,18 @@ public class MongoWrapperTest {
     }
 
     @Test
-    public void checkConnectionWithEmptyCredentials() throws Exception {
+    public void checkConnectionWithCredentials() {
         Map<String, Object> configMap = new HashMap<>();
-        configMap.put(MONGO_USERNAME, "");
-        configMap.put(MONGO_PASSWORD, "");
-        configMap.put(MONGO_PORT, MONGO_PORT_DEFAULT + 1000);
-        configMap.put(MONGO_HOST, "localhost");
-        configMap.put(MONGO_DATABASE, "mydb");
+        configMap.put(MONGO_URI, "mongodb://myuser:mypassword@localhost:28017/mydb");
         configMap.put(COLLECTION_FORMAT, "{$topic}");
         configMap.put(TOPICS_CONFIG, "a");
 
-        Field credentialsField = MongoWrapper.class.getDeclaredField("credentials");
-        credentialsField.setAccessible(true);
-        MongoClientOptions timeout = MongoClientOptions.builder()
+        MongoClientOptions.Builder timeout = MongoClientOptions.builder()
                 .connectTimeout(1)
                 .socketTimeout(1)
-                .serverSelectionTimeout(1)
-                .build();
+                .serverSelectionTimeout(1);
         MongoWrapper wrapper = new MongoWrapper(new AbstractConfig(CONFIG_DEF, configMap), timeout);
 
-        assertThat(credentialsField.get(wrapper), is(nullValue()));
-        assertFalse(wrapper.checkConnection());
-
-        thrown.expect(MongoException.class);
-        try {
-            wrapper.store("mytopic", new Document());
-        } finally {
-            wrapper.close();
-        }
-    }
-
-    @Test
-    public void checkConnectionWithCredentials() throws Exception {
-        Map<String, Object> configMap = new HashMap<>();
-        configMap.put(MONGO_USERNAME, "myuser");
-        configMap.put(MONGO_PASSWORD, "mypassword");
-        configMap.put(MONGO_PORT, MONGO_PORT_DEFAULT + 1000);
-        configMap.put(MONGO_HOST, "localhost");
-        configMap.put(MONGO_DATABASE, "mydb");
-        configMap.put(COLLECTION_FORMAT, "{$topic}");
-        configMap.put(TOPICS_CONFIG, "a");
-
-        Field credentialsField = MongoWrapper.class.getDeclaredField("credentials");
-        credentialsField.setAccessible(true);
-        MongoClientOptions timeout = MongoClientOptions.builder()
-                .connectTimeout(1)
-                .socketTimeout(1)
-                .serverSelectionTimeout(1)
-                .build();
-        MongoWrapper wrapper = new MongoWrapper(new AbstractConfig(CONFIG_DEF, configMap), timeout);
-
-        assertThat(credentialsField.get(wrapper), is(not(nullValue())));
         assertFalse(wrapper.checkConnection());
 
         thrown.expect(MongoException.class);


### PR DESCRIPTION
Fixes #44.
This update lets MongoDB do the parsing of its parameters, by providing a single URI. This is a breaking change that reduces the amount of configuration parameters a lot.