### PR TITLE
Fixed some error related offsets collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ Modify [sink.properties](https://github.com/RADAR-base/MongoDb-Sink-Connector/bl
 <tr>
 <td>mongo.collection.format</td></td><td>A format string for the destination collection name, which may contain `${topic}` as a placeholder for the originating topic name.
 For example, `kafka_${topic}` for the topic `orders` will map to the collection name `kafka_orders`.</td></td><td>string</td></td><td>{$topic}</td></td><td>Non-empty string</td></td><td>medium</td></td></tr>
+<tr>
+<td>mongo.offset.collection</td></td><td>The mongo collection for storage the latest offset processed.</td></td><td>string</td></td><td>OFFSETS</td></td><td></td></td><td>medium</td></td></tr>
 </tbody></table>
 
 - A sample configuration may look as below.

--- a/src/main/java/org/radarcns/connect/mongodb/MongoDbSinkConnector.java
+++ b/src/main/java/org/radarcns/connect/mongodb/MongoDbSinkConnector.java
@@ -58,6 +58,8 @@ public class MongoDbSinkConnector extends SinkConnector {
     public static final int BATCH_FLUSH_MS_DEFAULT = 15_000;
     public static final String COLLECTION_FORMAT = "mongo.collection.format";
     public static final String RECORD_CONVERTER = "record.converter.class";
+    public static final String OFFSET_COLLECTION_DEFAULT = "OFFSETS";
+    public static final String OFFSET_COLLECTION = "mongo.offset.collection";
 
     static final ConfigDef CONFIG_DEF = new ConfigDef()
             .define(MONGO_URI, Type.STRING, NO_DEFAULT_VALUE, new ValidMongoUri(), HIGH,
@@ -69,6 +71,10 @@ public class MongoDbSinkConnector extends SinkConnector {
                 + "For example, `kafka_${topic}` for the topic `orders` will map to the "
                 + "collection name `kafka_orders`.", MONGO_GROUP, 5, ConfigDef.Width.LONG,
                 "MongoDB collection name format")
+            .define(OFFSET_COLLECTION, Type.STRING, OFFSET_COLLECTION_DEFAULT,
+                    MEDIUM, "The mongo collection for storage "
+                            + "the latest offset processed. Default: "
+                            + OFFSET_COLLECTION_DEFAULT)
             .define(TOPICS_CONFIG, Type.LIST, NO_DEFAULT_VALUE, HIGH,
                 "List of topics to be streamed.")
             .define(BUFFER_CAPACITY, Type.INT, BUFFER_CAPACITY_DEFAULT,

--- a/src/main/java/org/radarcns/connect/mongodb/MongoDbWriter.java
+++ b/src/main/java/org/radarcns/connect/mongodb/MongoDbWriter.java
@@ -54,7 +54,7 @@ import java.util.stream.Collectors;
 public class MongoDbWriter implements Closeable, Runnable {
     private static final Logger logger = LoggerFactory.getLogger(MongoDbWriter.class);
     private static final int NUM_RETRIES = 3;
-    private static final String OFFSETS_COLLECTION = "OFFSETS";
+    private final String offsetCollection;
 
     private final MongoWrapper mongoHelper;
     private final BlockingQueue<SinkRecord> buffer;
@@ -77,10 +77,13 @@ public class MongoDbWriter implements Closeable, Runnable {
      * @throws ConnectException if cannot connect to the MongoDB database.
      */
     public MongoDbWriter(MongoWrapper mongoHelper, BlockingQueue<SinkRecord> buffer,
-            int maxBufferSize, long flushMs, RecordConverterFactory converterFactory, Timer timer)
+                         String offsetCollection, int maxBufferSize, long flushMs,
+                         RecordConverterFactory converterFactory, Timer timer)
             throws ConnectException {
         this.buffer = buffer;
         this.monitor = new Monitor(logger, "have been written in MongoDB", this.buffer);
+        this.offsetCollection = offsetCollection;
+
         timer.schedule(monitor, 0, 30_000);
 
         latestOffsets = new HashMap<>();
@@ -274,7 +277,7 @@ public class MongoDbWriter implements Closeable, Runnable {
                 Document doc = new Document();
                 doc.put("_id", id);
                 doc.put("offset", offset.getValue());
-                mongoHelper.store(OFFSETS_COLLECTION, doc);
+                mongoHelper.store(offsetCollection, doc);
             }
         } catch (MongoException ex) {
             logger.warn("Failed to store offsets to MongoDB", ex);
@@ -282,7 +285,9 @@ public class MongoDbWriter implements Closeable, Runnable {
     }
 
     private void retrieveOffsets() {
-        MongoIterable<Document> documentIterable = mongoHelper.getDocuments(OFFSETS_COLLECTION);
+        logger.info("Retrieve offsets from collection: {}", offsetCollection);
+        MongoIterable<Document> documentIterable =
+                mongoHelper.getDocuments(offsetCollection, false);
         try (MongoCursor<Document> documents = documentIterable.iterator()) {
             while (documents.hasNext()) {
                 Document doc = documents.next();
@@ -340,8 +345,9 @@ public class MongoDbWriter implements Closeable, Runnable {
         }
 
         public String getId() {
-            String value = (String) getDocument().get("_id");
-            return value != null ? value : UUID.randomUUID().toString();
+            Object value = getDocument().get("_id");
+            String valStr = value.toString();
+            return valStr != null ? valStr  : UUID.randomUUID().toString();
         }
     }
 }

--- a/src/main/java/org/radarcns/connect/mongodb/MongoWrapper.java
+++ b/src/main/java/org/radarcns/connect/mongodb/MongoWrapper.java
@@ -107,7 +107,7 @@ public class MongoWrapper implements Closeable {
      * @throws MongoException if the document could not be stored.
      */
     public void store(String topic, Document doc) throws MongoException {
-        MongoCollection<Document> collection = getCollection(topic);
+        MongoCollection<Document> collection = getCollection(topic, true);
         Object mongoId = doc.get(MONGO_ID_KEY);
         if (mongoId != null) {
             collection.replaceOne(eq(MONGO_ID_KEY, mongoId), doc, UPDATE_UPSERT);
@@ -125,7 +125,7 @@ public class MongoWrapper implements Closeable {
      * @throws MongoException if a document could not be stored.
      */
     public void store(String topic, Stream<Document> docs) throws MongoException {
-        getCollection(topic).bulkWrite(docs
+        getCollection(topic, true).bulkWrite(docs
                 .map(doc -> {
                     Object mongoId = doc.get(MONGO_ID_KEY);
                     if (mongoId != null) {
@@ -137,15 +137,16 @@ public class MongoWrapper implements Closeable {
                 .collect(Collectors.toList()));
     }
 
-    private MongoCollection<Document> getCollection(String topic) {
+    private MongoCollection<Document> getCollection(String topic, boolean useCollectionFormat) {
         return collectionCache.computeIfAbsent(topic,
-                t -> database.getCollection(collectionFormat.replace("{$topic}", t)));
+                t -> database.getCollection(useCollectionFormat
+                        ? collectionFormat.replace("{$topic}", t) : t));
     }
 
     /**
      * Retrieves all documents in a collection.
      */
-    public MongoIterable<Document> getDocuments(String topic) {
-        return getCollection(topic).find();
+    public MongoIterable<Document> getDocuments(String topic, boolean useCollectionFormat) {
+        return getCollection(topic, useCollectionFormat).find();
     }
 }

--- a/src/test/java/org/radarcns/connect/mongodb/MongoDbSinkTaskTest.java
+++ b/src/test/java/org/radarcns/connect/mongodb/MongoDbSinkTaskTest.java
@@ -50,7 +50,7 @@ public class MongoDbSinkTaskTest {
 
         //noinspection unchecked
         doAnswer(answer).when(sinkTask)
-                .createMongoDbWriter(any(), any(), anyInt(), anyLong(), any(), any());
+                .createMongoDbWriter(any(), any(), any(), anyInt(), anyLong(), any(), any());
 
         Map<String, String> config = new HashMap<>();
         config.put(MONGO_URI, "mongodb://localhost/db");

--- a/src/test/java/org/radarcns/connect/mongodb/MongoDbWriterTest.java
+++ b/src/test/java/org/radarcns/connect/mongodb/MongoDbWriterTest.java
@@ -64,7 +64,7 @@ public class MongoDbWriterTest {
         partDoc.put("offset", 999L);
 
         when(iterator.next()).thenReturn(partDoc);
-        when(wrapper.getDocuments("OFFSETS")).thenReturn(iterable);
+        when(wrapper.getDocuments("OFFSETS", false)).thenReturn(iterable);
 
         BlockingQueue<SinkRecord> buffer = new LinkedBlockingQueue<>();
 
@@ -87,7 +87,8 @@ public class MongoDbWriterTest {
 
         Timer timer = mock(Timer.class);
 
-        MongoDbWriter writer = new MongoDbWriter(wrapper, buffer, 1000, 1, factory, timer);
+        MongoDbWriter writer = new MongoDbWriter(wrapper, buffer,
+                "OFFSETS",1000, 1, factory, timer);
         verify(timer).schedule(any(Monitor.class), eq(0L), eq(30_000L));
 
         Thread writerThread = new Thread(writer, "MongoDB-writer");


### PR DESCRIPTION
- `timerThread` must canceled before cancel `writerThread` in `MongoDbSinkTask`.
- With `OFFSETS_COLLECTION` no need using `collectionFormat` in `MongoDbWriter`.
- Allowed using any type of ID (such as `Mongo ObjectID`) instead of `String` at present in `KafkaDocument.getId()`.
- New configuration `mongo.offset.collection`: The mongo collection for storage the latest offset processed (default `OFFSETS`)